### PR TITLE
fix: add process.env.port to url in swagger

### DIFF
--- a/config/swagger.js
+++ b/config/swagger.js
@@ -25,7 +25,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://localhost:8085/',
+        url: `http://localhost:${process.env.PORT}`,
         description: 'Local server',
       },
     ],


### PR DESCRIPTION
small fix to add process.env.port to url in swagger instead of hardcoding.